### PR TITLE
Fix: line breaks on descriptions

### DIFF
--- a/vitaes-webapp/src/Builder/CvItemForm/CvField/index.js
+++ b/vitaes-webapp/src/Builder/CvItemForm/CvField/index.js
@@ -29,7 +29,7 @@ class CvField extends Component {
             onChange={this.props.stateChanger}
             placeholder={this.props.placeholder}
             onKeyPress={(e) => {
-              if (e.key === 'Enter') {
+              if (e.key === 'Enter' && this.props.id !== 'description') {
                 this.props.addField();
               }
             }}


### PR DESCRIPTION
Fix: enter key was adding the entry on description fields, so there was no line break