### PR TITLE
Fix(#192): Remove "Curriculum Vitae" from bottom of the awesome template

### DIFF
--- a/vitaes-renderer/Templates/awesome/main.tex
+++ b/vitaes-renderer/Templates/awesome/main.tex
@@ -86,7 +86,7 @@
 % Leave any of these blank if they are not needed
 \makecvfooter
   {}
-  {$name ~~~·~~~Curriculum Vitae}
+  {$name}
   {}
 
 #for $section in $params['section_order']


### PR DESCRIPTION
Closes #192 