### PR TITLE
solve bug with items on awesome template

### DIFF
--- a/vitaes-renderer/Renders.py
+++ b/vitaes-renderer/Renders.py
@@ -171,10 +171,12 @@ class CvRenderCheetahTemplate(CvRenderBase):
                 skills[text_clean(skill.skill_type)].append(text_clean(skill.skill_name))
         return skills
 
-    def break_into_items(description, header=None, bottom=None, itemPrefix="", itemSuffix=""):
+    def break_into_items(description, header=None, bottom=None, itemPrefix="", itemSuffix="", itemSpacing=""):
         lines = description.split('\n')
         while len(lines) > 0 and lines[-1].strip() == '':
             lines = lines[:-1]
+        itemOnTop = [itemSpacing] if len(lines) > 0 and len(lines[0]) > 1 and lines[0][0] == '*' else []
+        itemOnBottom = [itemSpacing] if len(lines) > 0 and len(lines[-1]) > 1 and lines[-1][0] == '*' else []
         lines.append('')
         depth = 0
         retLines = []
@@ -194,6 +196,7 @@ class CvRenderCheetahTemplate(CvRenderBase):
                 retLines.append(itemPrefix + line[depth:] + itemSuffix)
             else: 
                 retLines.append(line)
+        retLines = itemOnTop + retLines[:-1] + itemOnBottom + [retLines[-1]]
         return '\n'.join(retLines)
 
     def render(cv: CurriculumVitae, baseFolder: str, params={}, resources={}):

--- a/vitaes-renderer/Templates/awesome/awesome-cv.cls
+++ b/vitaes-renderer/Templates/awesome/awesome-cv.cls
@@ -639,7 +639,6 @@
 
 % Define an environment for cvitems(for cventry)
 \newenvironment{cvitems}{%
-  \vspace{-4.0mm}
   \begin{justify}
   \begin{itemize}[leftmargin=2ex, nosep, noitemsep]
     \setlength{\parskip}{0pt}
@@ -647,7 +646,6 @@
 }{%
   \end{itemize}
   \end{justify}
-  \vspace{-4.0mm}
 }
 
 

--- a/vitaes-renderer/Templates/awesome/main.tex
+++ b/vitaes-renderer/Templates/awesome/main.tex
@@ -115,7 +115,7 @@
 #end if
     } % Date(s)
 #if 'description' in $education
-{$break_into_items($education['description'], header="\\begin{cvitems}", bottom="\\end{cvitems}", itemPrefix="\\item{", itemSuffix="}")}
+{$break_into_items($education['description'], header="\\begin{cvitems}", bottom="\\end{cvitems}", itemPrefix="\\item{", itemSuffix="}", itemSpacing="\\vspace{-4.0mm}")}
 #else
 {}
 #end if
@@ -153,7 +153,7 @@ $work['city']
 #end if
 } % Date(s)
 #if 'description' in $work
-{$break_into_items($work['description'], header="\\begin{cvitems}", bottom="\\end{cvitems}", itemPrefix="\\item{", itemSuffix="}")}
+{$break_into_items($work['description'], header="\\begin{cvitems}", bottom="\\end{cvitems}", itemPrefix="\\item{", itemSuffix="}", itemSpacing="\\vspace{-4.0mm}")}
 #else
 {}
 #end if
@@ -216,7 +216,7 @@ $project['city']
 #end if
 } % Date(s)
 #if 'description' in $project
-{$break_into_items($project['description'], header="\\begin{cvitems}", bottom="\\end{cvitems}", itemPrefix="\\item{", itemSuffix="}")}
+{$break_into_items($project['description'], header="\\begin{cvitems}", bottom="\\end{cvitems}", itemPrefix="\\item{", itemSuffix="}", itemSpacing="\\vspace{-4.0mm}")}
 #else
 {}
 #end if
@@ -257,7 +257,7 @@ $academic['city']
 #end if
 } % Date(s)
 #if 'description' in $academic
-{$break_into_items($academic['description'], header="\\begin{cvitems}", bottom="\\end{cvitems}", itemPrefix="\\item{", itemSuffix="}")}
+{$break_into_items($academic['description'], header="\\begin{cvitems}", bottom="\\end{cvitems}", itemPrefix="\\item{", itemSuffix="}", itemSpacing="\\vspace{-4.0mm}")}
 #else
 {}
 #end if


### PR DESCRIPTION
Closes #87 

There was a bug in awesome template that proactively removes 4mm from vertical margins to avoid blank spaces on sections. This results in unexpected behavior when mixing items with text. This PR solves this by only applying the vertical margin if there is no text above or bellow any text.