### PR TITLE
Fix node version used by webapp

### DIFF
--- a/vitaes-webapp/Dockerfile
+++ b/vitaes-webapp/Dockerfile
@@ -1,5 +1,5 @@
-FROM node:slim as react-build
+FROM node:11.14-slim as react-build
 WORKDIR /project
-copy package.json yarn.lock ./
+COPY package.json yarn.lock ./
 RUN yarn
 COPY . .


### PR DESCRIPTION
Node released v12 and for some reason travis is unable to download GRPC, so we are enforcing usage of v11.14.