### PR TITLE
final touchs for deploying to production with k8s

### DIFF
--- a/api/main.go
+++ b/api/main.go
@@ -136,8 +136,8 @@ func main() {
 
 	c := cors.New(cors.Options{
 		AllowedOrigins: []string{
-			"http://localhost", "http://vitaes.io", "http://k8s.vitaes.io",
-			"https://localhost", "https://vitaes.io", "https://k8s.vitaes.io",
+			"http://localhost", "http://vitaes.io",
+			"https://localhost", "https://vitaes.io",
 		},
 		AllowCredentials: true,
 	})

--- a/kubernetes/grafana.yaml
+++ b/kubernetes/grafana.yaml
@@ -18,7 +18,7 @@ spec:
         imagePullPolicy: Always
         volumeMounts:
         - name: pvc-influxdb
-          mountPath: /data
+          mountPath: /var/lib/influxdb
           subPath: influxdb
       volumes:
         - name: pvc-influxdb
@@ -47,8 +47,10 @@ spec:
         imagePullPolicy: Always
         volumeMounts:
         - name: pvc-grafana
-          mountPath: /data
+          mountPath: /var/lib/grafana
           subPath: grafana
+      securityContext:
+        fsGroup: 472
       volumes:
         - name: pvc-grafana
           persistentVolumeClaim:

--- a/kubernetes/ingress.yaml
+++ b/kubernetes/ingress.yaml
@@ -6,37 +6,37 @@ metadata:
     nginx.ingress.kubernetes.io/rewrite-target: /
 spec:
   rules:
-  - host: k8s.vitaes.io
+  - host: vitaes.io
     http:
       paths:
       - backend:
           serviceName: webapp
           servicePort: 80
-  - host: api.k8s.vitaes.io
+  - host: api.vitaes.io
     http:
       paths:
       - backend:
           serviceName: api
           servicePort: 6000
-  - host: storage.k8s.vitaes.io
+  - host: storage.vitaes.io
     http:
       paths:
       - backend:
           serviceName: storage
           servicePort: 6000
-  - host: logger.k8s.vitaes.io
+  - host: logger.vitaes.io
     http:
       paths:
       - backend:
           serviceName: logger
           servicePort: 6000
-  - host: sqlite.k8s.vitaes.io
+  - host: sqlite.vitaes.io
     http:
       paths:
       - backend:
           serviceName: sqlite-web
           servicePort: 8080
-  - host: grafana.k8s.vitaes.io
+  - host: grafana.vitaes.io
     http:
       paths:
       - backend:

--- a/logger/main.go
+++ b/logger/main.go
@@ -57,8 +57,8 @@ func main() {
 
 	c := cors.New(cors.Options{
 		AllowedOrigins: []string{
-			"http://localhost", "http://vitaes.io", "http://k8s.vitaes.io",
-			"https://localhost", "https://vitaes.io", "https://k8s.vitaes.io",
+			"http://localhost", "http://vitaes.io",
+			"https://localhost", "https://vitaes.io",
 		},
 		AllowCredentials: true,
 	})

--- a/storage/main.go
+++ b/storage/main.go
@@ -107,8 +107,8 @@ func main() {
 
 	c := cors.New(cors.Options{
 		AllowedOrigins: []string{
-			"http://localhost", "http://vitaes.io", "http://k8s.vitaes.io",
-			"https://localhost", "https://vitaes.io", "https://k8s.vitaes.io",
+			"http://localhost", "http://vitaes.io",
+			"https://localhost", "https://vitaes.io",
 		},
 		AllowCredentials: true,
 	})

--- a/webapp/src/utils/getHostname.js
+++ b/webapp/src/utils/getHostname.js
@@ -13,7 +13,7 @@ const getHostname = (target, port) => {
     return `localhost:${port}`;
   }
 
-  return `${target}.k8s.vitaes.io`;
+  return `${target}.vitaes.io`;
 };
 
 


### PR DESCRIPTION
This PR:
- Removes k8s hostname references
- Corrects mountPath for grafana and influxdb
- Change grafana's user id (bug after grafana's update)