### PR TITLE
Make typeform version 1

### DIFF
--- a/webapp/src/App.css
+++ b/webapp/src/App.css
@@ -35,6 +35,10 @@ body, .bg-secondary {
 .color-white {
   color: #FAFCFD; 
 }
+
+.unfocused {
+  opacity: 0.1;
+}
 /**/
 
 

--- a/webapp/src/AppRouter/routes.js
+++ b/webapp/src/AppRouter/routes.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import _ from 'lodash';
 
-import Builder from 'Builder';
+import BuilderV2 from 'BuilderV2';
 import AlertManager from 'AlertManager';
 import About from 'About';
 import PrivacyPolicy from 'PrivacyPolicy';
@@ -26,7 +26,7 @@ const getI18nPaths = (rawPaths) => {
 };
 
 export const rawPaths = [
-  { path: '/', component: () => <Builder />, exact: true },
+  { path: '/', component: () => <BuilderV2 />, exact: true },
   { path: '/alert-manager', component: () => <AlertManager />, exact: true },
   { path: '/about', component: () => <About />, exact: true },
   { path: '/privacy', component: () => <PrivacyPolicy />, exact: true },

--- a/webapp/src/BuilderV2/index.js
+++ b/webapp/src/BuilderV2/index.js
@@ -1,25 +1,23 @@
-import React from "react";
-import TypeForm from "Typeform";
-import TextInput from "Typeform/TextInput";
+import React from 'react';
+import TypeForm from 'Typeform';
+import TextInput from 'Typeform/TextInput';
 
-function BuilderV2(props) {
-    return (
-        <div className="d-flex flex-row h-100 align-items-center">
-            <div className="d-flex flex-column justify-content-left">
-                <div style={{height:'300px', border: '2px solid black', width: '250px'}}></div>
-                <div style={{height:'100px', border: '2px solid black', width: '250px'}}></div>
-            </div>
-            <div className="d-flex justify-content-center align-items-center">
-                <TypeForm>
-                    <TextInput></TextInput>
-                </TypeForm>
-                <TypeForm>
-                </TypeForm>
-                <TypeForm>
-                </TypeForm>
-            </div>
-        </div>
-    ) 
+function BuilderV2() {
+  return (
+    <div className="d-flex flex-row h-100 align-items-center">
+      <div className="d-flex flex-column justify-content-left">
+        <div style={{ height: '300px', border: '2px solid black', width: '250px' }} />
+        <div style={{ height: '100px', border: '2px solid black', width: '250px' }} />
+      </div>
+      <div className="d-flex justify-content-center align-items-center">
+        <TypeForm>
+          <TextInput />
+        </TypeForm>
+        <TypeForm />
+        <TypeForm />
+      </div>
+    </div>
+  );
 }
 
 export default BuilderV2;

--- a/webapp/src/BuilderV2/index.js
+++ b/webapp/src/BuilderV2/index.js
@@ -1,0 +1,25 @@
+import React from "react";
+import TypeForm from "Typeform";
+import TextInput from "Typeform/TextInput";
+
+function BuilderV2(props) {
+    return (
+        <div className="d-flex flex-row h-100 align-items-center">
+            <div className="d-flex flex-column justify-content-left">
+                <div style={{height:'300px', border: '2px solid black', width: '250px'}}></div>
+                <div style={{height:'100px', border: '2px solid black', width: '250px'}}></div>
+            </div>
+            <div className="d-flex justify-content-center align-items-center">
+                <TypeForm>
+                    <TextInput></TextInput>
+                </TypeForm>
+                <TypeForm>
+                </TypeForm>
+                <TypeForm>
+                </TypeForm>
+            </div>
+        </div>
+    ) 
+}
+
+export default BuilderV2;

--- a/webapp/src/NavBar/index.js
+++ b/webapp/src/NavBar/index.js
@@ -73,7 +73,7 @@ function NavBar(props) {
             <DevMenu hasPermissions={user && permissions ? permissions[user.uid] : null} />
             <Dropdown alignRight className="mr-5 mt-2">
               <Dropdown.Toggle as={LanguageToggle} flag={flag}></Dropdown.Toggle>
-              <Dropdown.Menu as={LanguageMenu} style={{ 'min-width': '1rem', 'max-width': '4rem', 'max-height': '6rem' }} className="p-2">
+              <Dropdown.Menu as={LanguageMenu} style={{ 'minWidth': '1rem', 'maxWidth': '4rem', 'maxHeight': '6rem' }} className="p-2">
                 <Dropdown.Item className="pl-1 w-20" onClick={() => changeLanguage('pt_BR')}>
                   <img alt="brazil flag" width="30px" height="20px" src="/flag-pt_BR.png" />
                 </Dropdown.Item>

--- a/webapp/src/NavBar/index.js
+++ b/webapp/src/NavBar/index.js
@@ -73,7 +73,7 @@ function NavBar(props) {
             <DevMenu hasPermissions={user && permissions ? permissions[user.uid] : null} />
             <Dropdown alignRight className="mr-5 mt-2">
               <Dropdown.Toggle as={LanguageToggle} flag={flag}></Dropdown.Toggle>
-              <Dropdown.Menu as={LanguageMenu} style={{ 'minWidth': '1rem', 'maxWidth': '4rem', 'maxHeight': '6rem' }} className="p-2">
+              <Dropdown.Menu as={LanguageMenu} style={{ minWidth: '1rem', maxWidth: '4rem', maxHeight: '6rem' }} className="p-2">
                 <Dropdown.Item className="pl-1 w-20" onClick={() => changeLanguage('pt_BR')}>
                   <img alt="brazil flag" width="30px" height="20px" src="/flag-pt_BR.png" />
                 </Dropdown.Item>

--- a/webapp/src/Typeform/ScrollWatcher/index.js
+++ b/webapp/src/Typeform/ScrollWatcher/index.js
@@ -1,0 +1,52 @@
+import React, { useState, useEffect } from "react";
+
+const atScrollFocus = (ref) => {
+    return (ref.getBoundingClientRect().top + window.scrollY) > window.scrollY;
+};
+
+const updateChildrenClass = (children) => {
+    return React.Children.map(children, (child) => {
+        const ref = child.ref.current;
+        
+        const isFocused = atScrollFocus(ref);
+
+        let className = child.props.className;
+
+        if (!isFocused) {
+            if (className) {
+                className += ' unfocused';
+            } else {
+                className = 'unfocused';
+            }
+        }   
+
+        return React.cloneElement(child, {
+            className
+        })
+    })
+}
+
+function ScrollWatcher(props) {
+    const { children } = props;
+    const [childrenFocused, setChildren] = useState(children);
+
+    useEffect(() => {
+
+        const updateVisbility = () => {
+            const newChildren = updateChildrenClass(children);
+            setChildren(newChildren);
+        }
+
+        window.addEventListener("scroll", () => { updateVisbility() });
+    }, [])
+
+    return (
+        <React.Fragment>
+            {
+                childrenFocused
+            }
+        </React.Fragment>
+    )
+}
+
+export default ScrollWatcher;

--- a/webapp/src/Typeform/ScrollWatcher/index.js
+++ b/webapp/src/Typeform/ScrollWatcher/index.js
@@ -1,52 +1,47 @@
-import React, { useState, useEffect } from "react";
+import React, { useState, useEffect } from 'react';
 
-const atScrollFocus = (ref) => {
-    return (ref.getBoundingClientRect().top + window.scrollY) > window.scrollY;
-};
+const atScrollFocus = ref => (ref.getBoundingClientRect().top + window.scrollY) > window.scrollY;
 
-const updateChildrenClass = (children) => {
-    return React.Children.map(children, (child) => {
-        const ref = child.ref.current;
-        
-        const isFocused = atScrollFocus(ref);
+const updateChildrenClass = children => React.Children.map(children, (child) => {
+  const ref = child.ref.current;
 
-        let className = child.props.className;
+  const isFocused = atScrollFocus(ref);
 
-        if (!isFocused) {
-            if (className) {
-                className += ' unfocused';
-            } else {
-                className = 'unfocused';
-            }
-        }   
+  let { className } = child.props;
 
-        return React.cloneElement(child, {
-            className
-        })
-    })
-}
+  if (!isFocused) {
+    if (className) {
+      className += ' unfocused';
+    } else {
+      className = 'unfocused';
+    }
+  }
+
+  return React.cloneElement(child, {
+    className,
+  });
+});
 
 function ScrollWatcher(props) {
-    const { children } = props;
-    const [childrenFocused, setChildren] = useState(children);
+  const { children } = props;
+  const [childrenFocused, setChildren] = useState(children);
 
-    useEffect(() => {
+  useEffect(() => {
+    const updateVisbility = () => {
+      const newChildren = updateChildrenClass(children);
+      setChildren(newChildren);
+    };
 
-        const updateVisbility = () => {
-            const newChildren = updateChildrenClass(children);
-            setChildren(newChildren);
-        }
+    window.addEventListener('scroll', () => { updateVisbility(); });
+  }, []);
 
-        window.addEventListener("scroll", () => { updateVisbility() });
-    }, [])
-
-    return (
-        <React.Fragment>
-            {
+  return (
+    <React.Fragment>
+      {
                 childrenFocused
             }
-        </React.Fragment>
-    )
+    </React.Fragment>
+  );
 }
 
 export default ScrollWatcher;

--- a/webapp/src/Typeform/TextInput/index.js
+++ b/webapp/src/Typeform/TextInput/index.js
@@ -1,0 +1,11 @@
+import React from "react";
+
+const TextInput = React.forwardRef((props, ref) => {
+    return (
+        <div ref={ref}>
+            <input placeholder={props.placeholder} className={props.className} type="text" name={props.name}></input>   
+        </div>
+    )
+})
+
+export default TextInput;   

--- a/webapp/src/Typeform/TextInput/index.js
+++ b/webapp/src/Typeform/TextInput/index.js
@@ -1,11 +1,9 @@
-import React from "react";
+import React from 'react';
 
-const TextInput = React.forwardRef((props, ref) => {
-    return (
-        <div ref={ref}>
-            <input placeholder={props.placeholder} className={props.className} type="text" name={props.name}></input>   
-        </div>
-    )
-})
+const TextInput = React.forwardRef((props, ref) => (
+  <div ref={ref}>
+    <input placeholder={props.placeholder} className={props.className} type="text" name={props.name} />
+  </div>
+));
 
-export default TextInput;   
+export default TextInput;

--- a/webapp/src/Typeform/index.js
+++ b/webapp/src/Typeform/index.js
@@ -1,20 +1,19 @@
-import React, { useRef } from "react";
-import ScrollWatcher from "./ScrollWatcher";
+import React, { useRef } from 'react';
+import ScrollWatcher from './ScrollWatcher';
 
 function TypeForm(props) {
-    
-    const { children } = props;
+  const { children } = props;
 
-    return (
-        <ScrollWatcher>
-            {
+  return (
+    <ScrollWatcher>
+      {
                 React.Children.map(children, (child) => {
-                    const ref = useRef(null);
-                    return React.cloneElement(child, { ref });
-                })  
+                  const ref = useRef(null);
+                  return React.cloneElement(child, { ref });
+                })
             }
-        </ScrollWatcher>
-    ) 
+    </ScrollWatcher>
+  );
 }
 
 export default TypeForm;

--- a/webapp/src/Typeform/index.js
+++ b/webapp/src/Typeform/index.js
@@ -1,0 +1,20 @@
+import React, { useRef } from "react";
+import ScrollWatcher from "./ScrollWatcher";
+
+function TypeForm(props) {
+    
+    const { children } = props;
+
+    return (
+        <ScrollWatcher>
+            {
+                React.Children.map(children, (child) => {
+                    const ref = useRef(null);
+                    return React.cloneElement(child, { ref });
+                })  
+            }
+        </ScrollWatcher>
+    ) 
+}
+
+export default TypeForm;


### PR DESCRIPTION
Adding version 1 of typeform components, which decreases opacity of components that are not focused (related to the scroll bar).

- Input components needs forwardRef
- The effect is applied to every component that is inside `<Typeform>` tags