### PR TITLE
remove auto ack from renderer

### DIFF
--- a/renderer/Consumer.py
+++ b/renderer/Consumer.py
@@ -87,10 +87,10 @@ def get_cv_queue(ch, method, properties, body):
       }
     ]
     client.write_points(log)
+    ch.basic_ack(delivery_tag = method.delivery_tag)
 
 channel.basic_consume(queue='cv_requests',
-                      on_message_callback=get_cv_queue,
-                      auto_ack=True)
+                      on_message_callback=get_cv_queue)
 
 print(' [*] Waiting for messages. To exit press CTRL+C')
 channel.start_consuming()


### PR DESCRIPTION
Renderer should not be auto-acking RabbitMQ messages, cause we want them to stay on queue while the renderer instance is busy