### PR TITLE
add download .tex option

### DIFF
--- a/renderer/Common.py
+++ b/renderer/Common.py
@@ -63,3 +63,5 @@ def render_from_cv_dict(req):
         return Renders.CvRenderToJson.render(req_cv, path=path)
     elif render_format == "pdf":
         return Renders.CvRenderToPdf.render(cv, path=path, cvRender=Renders.CvRenderCheetahTemplate, baseFolder=baseFolder, command=render_map[render_key]['command'], params=params, resources=resources)
+    elif render_format == "zip":
+        return Renders.CvRenderToTex.render(cv, path=path, cvRender=Renders.CvRenderCheetahTemplate, baseFolder=baseFolder, params=params, resources=resources)

--- a/renderer/Common.py
+++ b/renderer/Common.py
@@ -58,10 +58,10 @@ def render_from_cv_dict(req):
       
     resources = get_resources(params['lang'][:2])
 
-    render_format = req["render_format"]
+    render_format = req["render_format"]["internal"]
     if render_format == "json":
         return Renders.CvRenderToJson.render(req_cv, path=path)
     elif render_format == "pdf":
         return Renders.CvRenderToPdf.render(cv, path=path, cvRender=Renders.CvRenderCheetahTemplate, baseFolder=baseFolder, command=render_map[render_key]['command'], params=params, resources=resources)
-    elif render_format == "zip":
+    elif render_format == "tex":
         return Renders.CvRenderToTex.render(cv, path=path, cvRender=Renders.CvRenderCheetahTemplate, baseFolder=baseFolder, params=params, resources=resources)

--- a/renderer/Consumer.py
+++ b/renderer/Consumer.py
@@ -50,7 +50,7 @@ def get_cv_queue(ch, method, properties, body):
         log_step(email, dic["path"], "CONSUMED_FROM_RABBITMQ")
         lang = dic["params"]["lang"]
         ans = render_from_cv_dict(dic)
-        file = open('Output/' + ans + '.' + dic["render_format"], 'rb')
+        file = open('Output/' + ans + '.' + dic["render_format"]["file"], 'rb')
         ansb = file.read()
         file.close()
         log_step(email, dic["path"], "SENDING_TO_STORAGE")

--- a/renderer/Renders.py
+++ b/renderer/Renders.py
@@ -1,4 +1,5 @@
 import datetime, time
+import shutil
 import string, random, os
 import subprocess, json
 import timestring
@@ -48,6 +49,23 @@ class CvRenderToPdf(CvRenderBase):
         p_output = p.stdout.read().decode("utf-8", errors='ignore')
         log_step(cv.header.email, cv.cv_hash, "LATEX_CMD_EXECUTED", p_output)
         os.system("cp Output/" + path + "/main.pdf Output/" + path + ".pdf")
+        os.system("rm -r Output/" + path + "/")
+        return path
+
+class CvRenderToTex(CvRenderBase):
+    def render(cv, cvRender: CvRenderBase, baseFolder: str, path: str=None, params={}, resources={}):
+        if path == None:
+            path=id_gen()
+        os.system("mkdir Output/" + path)
+        if baseFolder != None:
+            os.system("cp -r Templates/" + baseFolder + "/* Output/" + path + "/")
+        cvString = cvRender.render(cv, params=params, baseFolder=baseFolder, resources=resources)
+        log_step(cv.header.email, cv.cv_hash, "TEX_FULLY_COMPILED")
+        os.system("touch Output/" + path + "/main.tex")
+        file = open("Output/" + path + "/main.tex","w", encoding="utf-8") 
+        file.write(cvString)
+        file.close()
+        shutil.make_archive("Output/" + path, "zip", "Output/" + path + "/")
         os.system("rm -r Output/" + path + "/")
         return path
 

--- a/storage/main.go
+++ b/storage/main.go
@@ -49,7 +49,7 @@ func retrieveFile(w http.ResponseWriter, r *http.Request, client *redis.Client) 
 	email := vars["email"]
 	id := vars["cvid"]
 
-	fileFormat := parseQueryParam("file_format", r)
+	mimeContentType := parseQueryParam("mime_content_type", r)
 
 	res, err := client.Exists(id).Result()
 	if err != nil {
@@ -75,7 +75,7 @@ func retrieveFile(w http.ResponseWriter, r *http.Request, client *redis.Client) 
 		}
 		file := []byte(data)
 
-		w.Header().Set("Content-Type", "application/"+fileFormat)
+		w.Header().Set("Content-Type", mimeContentType)
 		w.Header().Set("Content-Length", strconv.Itoa(len(file)))
 		w.WriteHeader(http.StatusAccepted)
 		w.Write(file)

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -19,7 +19,7 @@
     "prop-types": "^15.7.2",
     "react": "^16.4.2",
     "react-autosize-textarea": "*",
-    "react-bootstrap": "^1.0.0-beta.5",
+    "react-bootstrap": "^1.2.2",
     "react-dom": "^16.4.2",
     "react-dropzone": "^10.1.3",
     "react-facebook-pixel": "^0.1.3",

--- a/webapp/src/Builder/Builder.js
+++ b/webapp/src/Builder/Builder.js
@@ -5,7 +5,8 @@ import fetch from 'fetch-retry';
 import { toast } from 'react-toastify';
 import _ from 'lodash';
 import {
-  Button, Form, Col, Row,
+  Button, Form, Col, Row, 
+  DropdownButton, ButtonGroup, Dropdown
 } from 'react-bootstrap';
 import Dropzone from 'react-dropzone';
 
@@ -25,6 +26,7 @@ import CvHeaderField from './CvHeaderField';
 import CvItemForm from './CvItemForm';
 import headerFields from './headerFields';
 import { cvFormFields, updateFormFields } from './cvFormFields';
+import cvDownloadFormats from './cvDownloadFormats';
 import ReactPixel from 'react-facebook-pixel';
 
 const autoSaveTime = 15000;
@@ -65,7 +67,7 @@ class Builder extends Component {
     this.props.userDataSetter(_.assign(userData, data));
   }
   
-  downloadCv(format) {
+  downloadCv(format, mimeContentType, fileFormat) {
     if (this.state.downloading) {
       return;
     }
@@ -95,7 +97,10 @@ class Builder extends Component {
       curriculum_vitae: cv,
       section_order: this.props.userData.cv_order,
       render_key: this.props.userData.user_cv_model,
-      render_format: format,
+      render_format: {
+        internal: format,
+        file: fileFormat,
+      },
       params,
     };
     requestCv.path = hashCv(requestCv);
@@ -117,7 +122,7 @@ class Builder extends Component {
         toast(`${translate('loading')}...`, { autoClose: false, toastId: 'downloading' });
         idPromise.then((id) => {
           fetch(
-            `${window.location.protocol}//${getStorageHostname()}/${id}/${this.props.userData.cv.header.email}/?file_format=${format}`,
+            `${window.location.protocol}//${getStorageHostname()}/${id}/${this.props.userData.cv.header.email}/?mime_content_type=${mimeContentType}`,
             {
               method: 'GET',
               retries: 20,
@@ -130,7 +135,7 @@ class Builder extends Component {
               fileBlob.then((file) => {
                 const element = document.createElement('a');
                 element.href = URL.createObjectURL(file);
-                element.download = `cv.${format}`;
+                element.download = `cv.${fileFormat}`;
                 element.click();
               });
               const serveTime = window.performance.now();
@@ -328,6 +333,26 @@ class Builder extends Component {
         {cvModelSuboptions}
         <br />
         <br />
+        <DropdownButton
+          disabled={this.state.downloading}
+          as={ButtonGroup}
+          title={translate('download_as')}
+          variant="secondary"
+          size="sm"
+          style={{ marginLeft: 5, float: 'right' }}
+        >
+        {_.map(cvDownloadFormats, downloadFormat => (
+          <Dropdown.Item 
+            onClick={() => this.downloadCv(
+              downloadFormat.id,
+              downloadFormat.mimeContentType,
+              downloadFormat.fileFormat
+            )}
+          >
+            {downloadFormat.descriptor}
+          </Dropdown.Item>
+        ))}
+        </DropdownButton>
         <Dropzone onDrop={files => this.uploadJSON(files)}>
           {({ getRootProps, getInputProps }) => (
             <Button
@@ -346,33 +371,6 @@ class Builder extends Component {
             </Button>
           )}
         </Dropzone>
-        <Button
-          disabled={this.state.downloading}
-          variant="secondary"
-          size="sm"
-          onClick={() => this.downloadCv("json")}
-          style={{ marginLeft: 5, float: 'right' }}
-        >
-          {translate('download_json')}
-        </Button>
-        <Button
-          disabled={this.state.downloading}
-          variant="secondary"
-          size="sm"
-          onClick={() => this.downloadCv("pdf")}
-          style={{ marginLeft: 5, float: 'right' }}
-        >
-          {translate('download_cv')}
-        </Button>
-        <Button
-          disabled={this.state.downloading}
-          variant="secondary"
-          size="sm"
-          onClick={() => this.downloadCv("zip")}
-          style={{ marginLeft: 5, float: 'right' }}
-        >
-          {translate('download_tex')}
-        </Button>
         {this.props.user !== null ? (
           <Button
             variant="secondary"

--- a/webapp/src/Builder/Builder.js
+++ b/webapp/src/Builder/Builder.js
@@ -364,6 +364,15 @@ class Builder extends Component {
         >
           {translate('download_cv')}
         </Button>
+        <Button
+          disabled={this.state.downloading}
+          variant="secondary"
+          size="sm"
+          onClick={() => this.downloadCv("zip")}
+          style={{ marginLeft: 5, float: 'right' }}
+        >
+          {translate('download_tex')}
+        </Button>
         {this.props.user !== null ? (
           <Button
             variant="secondary"

--- a/webapp/src/Builder/cvDownloadFormats.js
+++ b/webapp/src/Builder/cvDownloadFormats.js
@@ -1,0 +1,22 @@
+import { translate } from 'i18n/locale';
+
+export default [
+  {
+    id: 'tex',
+    descriptor: translate('tex_descriptor'),
+    mimeContentType: 'application/zip',
+    fileFormat: 'zip',
+  },
+  {
+    id: 'json',
+    descriptor: translate('json_descriptor'),
+    mimeContentType: 'application/json',
+    fileFormat: 'json',
+  },
+  {
+    id: 'pdf',
+    descriptor: translate('pdf_descriptor'),
+    mimeContentType: 'application/pdf',
+    fileFormat: 'pdf',
+  }
+]

--- a/webapp/src/i18n/strings.js
+++ b/webapp/src/i18n/strings.js
@@ -161,6 +161,10 @@ export const strings = {
     en_US: 'Download JSON',
     pt_BR: 'Baixar JSON',
   },
+  download_tex: {
+    en_US: 'Download TEX',
+    pt_BR: 'Baixar TEX',
+  },
   edit: {
     en_US: 'Edit',
     pt_BR: 'Editar',

--- a/webapp/src/i18n/strings.js
+++ b/webapp/src/i18n/strings.js
@@ -153,17 +153,21 @@ export const strings = {
     en_US: 'Dev options',
     pt_BR: 'Ferramentas de desenvolvedor',
   },
-  download_cv: {
-    en_US: 'Download CV',
-    pt_BR: 'Baixar CV',
+  download_as: {
+    en_US: 'Download as',
+    pt_BR: 'Baixar como',
   },
-  download_json: {
-    en_US: 'Download JSON',
-    pt_BR: 'Baixar JSON',
+  pdf_descriptor: {
+    en_US: 'PDF',
+    pt_BR: 'PDF',
   },
-  download_tex: {
-    en_US: 'Download TEX',
-    pt_BR: 'Baixar TEX',
+  json_descriptor: {
+    en_US: 'JSON',
+    pt_BR: 'JSON',
+  },
+  tex_descriptor: {
+    en_US: 'TEX',
+    pt_BR: 'TEX',
   },
   edit: {
     en_US: 'Edit',

--- a/webapp/yarn.lock
+++ b/webapp/yarn.lock
@@ -9573,7 +9573,7 @@ react-autosize-textarea@*:
     line-height "^0.3.1"
     prop-types "^15.5.6"
 
-react-bootstrap@^1.0.0-beta.5:
+react-bootstrap@^1.2.2:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/react-bootstrap/-/react-bootstrap-1.2.2.tgz#dbae0c3d4fb20cd545c8efc62f49190f690cea2b"
   integrity sha512-G+QcEyBqFtakBNghdDugie+yU/ABDeqw3n+SOeRGxEn1m0dbIyHTroZpectcQk6FB3aS4RJGkZTuLVYH86Cu2A==


### PR DESCRIPTION
This will make it possible to download the .tex file directly.

This is still not optimal, due to the fact that, strictly speaking, we are giving away the tex part, but in a .zip format with all necessary files. With this in mind, there should be a better handling of file extension, MIME Content-Type and proper "internal" format, but this should be done when tackling #301 

Fixes #402 